### PR TITLE
Add combat packet monitoring and diagnostics

### DIFF
--- a/anticheat/src/main/java/com/example/anticheat/combat/EmpiricalBaseline.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/EmpiricalBaseline.java
@@ -1,0 +1,39 @@
+package com.example.anticheat.combat;
+
+/**
+ * Represents empirically observed percentile ranges for a combat metric.
+ */
+public final class EmpiricalBaseline {
+    private final double lowerPercentile;
+    private final double upperPercentile;
+    private final double warmupGrace;
+
+    public EmpiricalBaseline(double lowerPercentile, double upperPercentile) {
+        this(lowerPercentile, upperPercentile, 0.0);
+    }
+
+    public EmpiricalBaseline(double lowerPercentile, double upperPercentile, double warmupGrace) {
+        if (lowerPercentile > upperPercentile) {
+            throw new IllegalArgumentException("Lower percentile cannot exceed upper percentile");
+        }
+        this.lowerPercentile = lowerPercentile;
+        this.upperPercentile = upperPercentile;
+        this.warmupGrace = warmupGrace;
+    }
+
+    public double getLowerPercentile() {
+        return lowerPercentile;
+    }
+
+    public double getUpperPercentile() {
+        return upperPercentile;
+    }
+
+    public double getWarmupGrace() {
+        return warmupGrace;
+    }
+
+    public boolean isWithin(double value) {
+        return value >= lowerPercentile && value <= upperPercentile;
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/PacketMonitor.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/PacketMonitor.java
@@ -1,0 +1,321 @@
+package com.example.anticheat.combat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalDouble;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Observes combat related packets to compute rolling statistics and trigger anti-cheat heuristics.
+ */
+public final class PacketMonitor {
+    public enum Metric {
+        ROTATIONS_PER_SECOND,
+        ROTATION_VARIANCE,
+        CLICKS_PER_SECOND,
+        PERFECT_YAW_LOCK,
+        CONSTANT_CPS
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(PacketMonitor.class.getName());
+    private static final Duration ROLLING_WINDOW = Duration.ofSeconds(6);
+    private static final Duration VIOLATION_DECAY = Duration.ofSeconds(45);
+    private static final int TRACE_CAPACITY = 256;
+    private static final double YAW_LOCK_EPSILON = 0.05D;
+    private static final int YAW_LOCK_WINDOW = 10;
+    private static final int CONSTANT_CPS_WINDOW = 12;
+
+    private final Map<UUID, SessionState> sessions = new ConcurrentHashMap<>();
+    private final Map<Metric, EmpiricalBaseline> baselines = new EnumMap<>(Metric.class);
+    private final Map<Metric, ViolationBuffer> violationBuffers = new EnumMap<>(Metric.class);
+    private final PunishmentManager punishmentManager;
+
+    public PacketMonitor(PunishmentManager punishmentManager) {
+        this.punishmentManager = Objects.requireNonNull(punishmentManager, "punishmentManager");
+        baselines.put(Metric.ROTATIONS_PER_SECOND, new EmpiricalBaseline(0.3, 4.8, 1.0));
+        baselines.put(Metric.ROTATION_VARIANCE, new EmpiricalBaseline(0.1, 120.0, 1.0));
+        baselines.put(Metric.CLICKS_PER_SECOND, new EmpiricalBaseline(3.0, 13.5, 1.0));
+        violationBuffers.put(Metric.ROTATIONS_PER_SECOND,
+                new ViolationBuffer(6.0, VIOLATION_DECAY, punishmentManager));
+        violationBuffers.put(Metric.ROTATION_VARIANCE,
+                new ViolationBuffer(6.0, VIOLATION_DECAY, punishmentManager));
+        violationBuffers.put(Metric.CLICKS_PER_SECOND,
+                new ViolationBuffer(6.0, VIOLATION_DECAY, punishmentManager));
+        violationBuffers.put(Metric.PERFECT_YAW_LOCK,
+                new ViolationBuffer(4.0, VIOLATION_DECAY, punishmentManager));
+        violationBuffers.put(Metric.CONSTANT_CPS,
+                new ViolationBuffer(4.0, VIOLATION_DECAY, punishmentManager));
+    }
+
+    public void recordRotation(UUID playerId, String playerName, float yaw, float pitch, long timestamp) {
+        handlePacket(playerId, playerName, PacketType.ROTATION, yaw, pitch, timestamp);
+    }
+
+    public void recordSwing(UUID playerId, String playerName, float yaw, float pitch, long timestamp) {
+        handlePacket(playerId, playerName, PacketType.SWING, yaw, pitch, timestamp);
+    }
+
+    public void recordAttack(UUID playerId, String playerName, float yaw, float pitch, long timestamp) {
+        handlePacket(playerId, playerName, PacketType.ATTACK, yaw, pitch, timestamp);
+    }
+
+    public List<TraceEntry> dumpTraces(UUID playerId) {
+        SessionState session = sessions.get(playerId);
+        if (session == null) {
+            return Collections.emptyList();
+        }
+        return session.getTraceEntries();
+    }
+
+    private void handlePacket(UUID playerId, String playerName, PacketType type, float yaw, float pitch,
+            long timestamp) {
+        SessionState session = sessions.computeIfAbsent(playerId,
+                ignored -> new SessionState(playerId, playerName));
+        SessionSnapshot snapshot = session.record(type, yaw, pitch, timestamp);
+        logPacket(session, type, snapshot);
+        evaluateBaselines(session, snapshot);
+        evaluateHeuristics(session);
+    }
+
+    private void logPacket(SessionState session, PacketType type, SessionSnapshot snapshot) {
+        if (!LOGGER.isLoggable(Level.FINE)) {
+            return;
+        }
+        LOGGER.log(Level.FINE,
+                () -> String.format(
+                        "[%s] %s %s yawΔ=%.3f pitchΔ=%.3f interval=%dms rps=%.2f(mean=%.2f) cps=%.2f(mean=%.2f)",
+                        session.playerName, type, session.playerId, snapshot.yawDelta, snapshot.pitchDelta,
+                        snapshot.intervalMillis, snapshot.instantRotationsPerSecond,
+                        snapshot.meanRotationsPerSecond, snapshot.instantCps, snapshot.meanCps));
+    }
+
+    private void evaluateBaselines(SessionState session, SessionSnapshot snapshot) {
+        long timestamp = snapshot.timestamp.toEpochMilli();
+        checkAgainstBaseline(session, Metric.ROTATIONS_PER_SECOND, snapshot.meanRotationsPerSecond, timestamp,
+                "mean rotation speed outside empirical range");
+        checkAgainstBaseline(session, Metric.ROTATION_VARIANCE, snapshot.rotationVariance, timestamp,
+                "rotation variance outside empirical range");
+        if (snapshot.meanCps > 0) {
+            checkAgainstBaseline(session, Metric.CLICKS_PER_SECOND, snapshot.meanCps, timestamp,
+                    "mean clicks per second outside empirical range");
+        }
+    }
+
+    private void checkAgainstBaseline(SessionState session, Metric metric, double value, long timestamp,
+            String reason) {
+        EmpiricalBaseline baseline = baselines.get(metric);
+        if (baseline == null) {
+            return;
+        }
+        if (session.rollingAgeSeconds < baseline.getWarmupGrace()) {
+            return;
+        }
+        if (baseline.isWithin(value)) {
+            session.resetBaselineViolations(metric);
+            return;
+        }
+        int strikes = session.incrementBaselineViolations(metric);
+        if (strikes >= 3) {
+            ViolationBuffer buffer = violationBuffers.get(metric);
+            if (buffer != null) {
+                buffer.addViolation(session.playerName, strikes, timestamp, reason);
+            }
+        }
+    }
+
+    private void evaluateHeuristics(SessionState session) {
+        long timestamp = session.lastPacketTimestamp;
+        if (detectPerfectYawLock(session)) {
+            ViolationBuffer buffer = violationBuffers.get(Metric.PERFECT_YAW_LOCK);
+            if (buffer != null) {
+                buffer.addViolation(session.playerName, 1.5, timestamp, "sustained perfect yaw lock");
+            }
+        }
+        if (detectConstantCps(session)) {
+            ViolationBuffer buffer = violationBuffers.get(Metric.CONSTANT_CPS);
+            if (buffer != null) {
+                buffer.addViolation(session.playerName, 1.5, timestamp, "constant CPS pattern");
+            }
+        }
+    }
+
+    private boolean detectPerfectYawLock(SessionState session) {
+        if (session.yawLockWindow.size() < YAW_LOCK_WINDOW) {
+            return false;
+        }
+        for (double delta : session.yawLockWindow) {
+            if (Math.abs(delta) > YAW_LOCK_EPSILON) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean detectConstantCps(SessionState session) {
+        if (session.attackIntervals.size() < CONSTANT_CPS_WINDOW) {
+            return false;
+        }
+        OptionalDouble meanOptional = session.attackIntervals.stream()
+                .mapToLong(Long::longValue)
+                .average();
+        if (meanOptional.isEmpty()) {
+            return false;
+        }
+        double meanInterval = meanOptional.getAsDouble();
+        double variance = 0.0;
+        for (long interval : session.attackIntervals) {
+            double delta = interval - meanInterval;
+            variance += delta * delta;
+        }
+        variance /= session.attackIntervals.size();
+        double stdDeviation = Math.sqrt(variance);
+        double cps = meanInterval <= 0 ? 0 : 1000.0 / meanInterval;
+        return cps >= 8.0 && cps <= 15.0 && stdDeviation <= 8.0;
+    }
+
+    private static final class SessionSnapshot {
+        private final UUID playerId;
+        private final Instant timestamp;
+        private final double yawDelta;
+        private final double pitchDelta;
+        private final long intervalMillis;
+        private final double instantRotationsPerSecond;
+        private final double meanRotationsPerSecond;
+        private final double rotationVariance;
+        private final double instantCps;
+        private final double meanCps;
+
+        private SessionSnapshot(UUID playerId, Instant timestamp, double yawDelta, double pitchDelta,
+                long intervalMillis, double instantRotationsPerSecond, double meanRotationsPerSecond,
+                double rotationVariance, double instantCps, double meanCps) {
+            this.playerId = playerId;
+            this.timestamp = timestamp;
+            this.yawDelta = yawDelta;
+            this.pitchDelta = pitchDelta;
+            this.intervalMillis = intervalMillis;
+            this.instantRotationsPerSecond = instantRotationsPerSecond;
+            this.meanRotationsPerSecond = meanRotationsPerSecond;
+            this.rotationVariance = rotationVariance;
+            this.instantCps = instantCps;
+            this.meanCps = meanCps;
+        }
+    }
+
+    private static final class SessionState {
+        private final UUID playerId;
+        private final String playerName;
+        private final RollingStatistics rotationSpeedStats = new RollingStatistics(ROLLING_WINDOW);
+        private final RollingStatistics yawDeltaStats = new RollingStatistics(ROLLING_WINDOW);
+        private final RollingStatistics cpsStats = new RollingStatistics(ROLLING_WINDOW);
+        private final ArrayDeque<TraceEntry> traces = new ArrayDeque<>(TRACE_CAPACITY);
+        private final ArrayDeque<Double> yawLockWindow = new ArrayDeque<>();
+        private final ArrayDeque<Long> attackIntervals = new ArrayDeque<>();
+        private final Map<Metric, Integer> baselineViolations = new EnumMap<>(Metric.class);
+
+        private long lastPacketTimestamp;
+        private long lastAttackTimestamp;
+        private double lastYaw;
+        private double lastPitch;
+        private boolean hasRotation;
+        private double rollingAgeSeconds;
+
+        private SessionState(UUID playerId, String playerName) {
+            this.playerId = playerId;
+            this.playerName = playerName;
+        }
+
+        private SessionSnapshot record(PacketType type, float yaw, float pitch, long timestamp) {
+            Instant instant = Instant.ofEpochMilli(timestamp);
+            long interval = lastPacketTimestamp == 0 ? 0 : timestamp - lastPacketTimestamp;
+            double deltaSeconds = interval <= 0 ? 0.0 : interval / 1000.0;
+            double yawDelta = hasRotation ? angleDelta(yaw, lastYaw) : 0.0;
+            double pitchDelta = hasRotation ? angleDelta(pitch, lastPitch) : 0.0;
+            if (!hasRotation) {
+                lastYaw = yaw;
+                lastPitch = pitch;
+                hasRotation = true;
+            }
+            lastPacketTimestamp = timestamp;
+            lastYaw = yaw;
+            lastPitch = pitch;
+            if (interval > 0) {
+                rollingAgeSeconds += Math.min(4.0, interval / 1000.0);
+            }
+
+            yawLockWindow.addLast(yawDelta);
+            if (yawLockWindow.size() > YAW_LOCK_WINDOW) {
+                yawLockWindow.removeFirst();
+            }
+
+            double instantRotationsPerSecond = deltaSeconds <= 0 ? 0.0 : Math.abs(yawDelta) / deltaSeconds;
+            rotationSpeedStats.addSample(instantRotationsPerSecond, timestamp);
+            yawDeltaStats.addSample(Math.abs(yawDelta), timestamp);
+
+            double meanRotationsPerSecond = rotationSpeedStats.mean();
+            double rotationVariance = rotationSpeedStats.variance() + yawDeltaStats.variance();
+
+            double instantCps = 0.0;
+            if (type == PacketType.ATTACK || type == PacketType.SWING) {
+                if (lastAttackTimestamp > 0) {
+                    long attackInterval = timestamp - lastAttackTimestamp;
+                    attackIntervals.addLast(attackInterval);
+                    if (attackIntervals.size() > CONSTANT_CPS_WINDOW) {
+                        attackIntervals.removeFirst();
+                    }
+                    if (attackInterval > 0) {
+                        instantCps = 1000.0 / attackInterval;
+                        cpsStats.addSample(instantCps, timestamp);
+                    }
+                }
+                lastAttackTimestamp = timestamp;
+            }
+            double meanCps = cpsStats.mean();
+            if (instantCps == 0.0 && meanCps > 0) {
+                instantCps = meanCps;
+            }
+
+            TraceEntry trace = new TraceEntry(instant, type, yawDelta, pitchDelta, interval,
+                    instantRotationsPerSecond, meanRotationsPerSecond, instantCps, meanCps);
+            traces.addLast(trace);
+            if (traces.size() > TRACE_CAPACITY) {
+                traces.removeFirst();
+            }
+
+            return new SessionSnapshot(playerId, instant, yawDelta, pitchDelta, interval,
+                    instantRotationsPerSecond, meanRotationsPerSecond, rotationVariance, instantCps, meanCps);
+        }
+
+        private List<TraceEntry> getTraceEntries() {
+            return Collections.unmodifiableList(new ArrayList<>(traces));
+        }
+
+        private void resetBaselineViolations(Metric metric) {
+            baselineViolations.remove(metric);
+        }
+
+        private int incrementBaselineViolations(Metric metric) {
+            return baselineViolations.merge(metric, 1, Integer::sum);
+        }
+
+        private static double angleDelta(double current, double previous) {
+            double delta = current - previous;
+            while (delta <= -180.0) {
+                delta += 360.0;
+            }
+            while (delta > 180.0) {
+                delta -= 360.0;
+            }
+            return delta;
+        }
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/PacketType.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/PacketType.java
@@ -1,0 +1,7 @@
+package com.example.anticheat.combat;
+
+public enum PacketType {
+    ATTACK,
+    SWING,
+    ROTATION
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/PunishmentManager.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/PunishmentManager.java
@@ -1,0 +1,54 @@
+package com.example.anticheat.combat;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Minimal facade that would typically interface with the broader punishment system.
+ */
+public final class PunishmentManager {
+    public static final class ViolationRecord {
+        private final String playerName;
+        private final String reason;
+        private final double severity;
+        private final Instant timestamp;
+
+        private ViolationRecord(String playerName, String reason, double severity, Instant timestamp) {
+            this.playerName = playerName;
+            this.reason = reason;
+            this.severity = severity;
+            this.timestamp = timestamp;
+        }
+
+        public String getPlayerName() {
+            return playerName;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public double getSeverity() {
+            return severity;
+        }
+
+        public Instant getTimestamp() {
+            return timestamp;
+        }
+    }
+
+    private final List<ViolationRecord> records = new LinkedList<>();
+
+    public synchronized void flagSuspect(String playerName, String reason, double severity) {
+        Objects.requireNonNull(playerName, "playerName");
+        Objects.requireNonNull(reason, "reason");
+        records.add(new ViolationRecord(playerName, reason, severity, Instant.now()));
+    }
+
+    public synchronized List<ViolationRecord> getRecords() {
+        return Collections.unmodifiableList(new LinkedList<>(records));
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/RollingStatistics.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/RollingStatistics.java
@@ -1,0 +1,69 @@
+package com.example.anticheat.combat;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Maintains a rolling window of numeric samples and provides descriptive statistics.
+ */
+public final class RollingStatistics {
+    private static final class Sample {
+        private final long timestamp;
+        private final double value;
+
+        private Sample(long timestamp, double value) {
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+    }
+
+    private final long windowMillis;
+    private final Deque<Sample> samples = new ArrayDeque<>();
+    private double sum;
+    private double sumSquares;
+
+    public RollingStatistics(Duration window) {
+        this.windowMillis = window.toMillis();
+    }
+
+    public void addSample(double value, long timestamp) {
+        Sample sample = new Sample(timestamp, value);
+        samples.addLast(sample);
+        sum += value;
+        sumSquares += value * value;
+        evictOld(timestamp);
+    }
+
+    public int size() {
+        return samples.size();
+    }
+
+    public double mean() {
+        if (samples.isEmpty()) {
+            return 0.0;
+        }
+        return sum / samples.size();
+    }
+
+    public double variance() {
+        if (samples.isEmpty()) {
+            return 0.0;
+        }
+        double mean = mean();
+        return Math.max(0.0, (sumSquares / samples.size()) - mean * mean);
+    }
+
+    public double standardDeviation() {
+        return Math.sqrt(variance());
+    }
+
+    private void evictOld(long now) {
+        long threshold = now - windowMillis;
+        while (!samples.isEmpty() && samples.peekFirst().timestamp < threshold) {
+            Sample sample = samples.removeFirst();
+            sum -= sample.value;
+            sumSquares -= sample.value * sample.value;
+        }
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/TraceEntry.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/TraceEntry.java
@@ -1,0 +1,82 @@
+package com.example.anticheat.combat;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Snapshot of a processed packet for developer diagnostics.
+ */
+public final class TraceEntry {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+            .ofPattern("HH:mm:ss.SSS")
+            .withZone(ZoneId.systemDefault());
+
+    private final Instant timestamp;
+    private final PacketType packetType;
+    private final double yawDelta;
+    private final double pitchDelta;
+    private final long intervalMillis;
+    private final double instantRotationsPerSecond;
+    private final double meanRotationsPerSecond;
+    private final double instantCps;
+    private final double meanCps;
+
+    TraceEntry(Instant timestamp, PacketType packetType, double yawDelta, double pitchDelta,
+            long intervalMillis, double instantRotationsPerSecond, double meanRotationsPerSecond,
+            double instantCps, double meanCps) {
+        this.timestamp = timestamp;
+        this.packetType = packetType;
+        this.yawDelta = yawDelta;
+        this.pitchDelta = pitchDelta;
+        this.intervalMillis = intervalMillis;
+        this.instantRotationsPerSecond = instantRotationsPerSecond;
+        this.meanRotationsPerSecond = meanRotationsPerSecond;
+        this.instantCps = instantCps;
+        this.meanCps = meanCps;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public PacketType getPacketType() {
+        return packetType;
+    }
+
+    public double getYawDelta() {
+        return yawDelta;
+    }
+
+    public double getPitchDelta() {
+        return pitchDelta;
+    }
+
+    public long getIntervalMillis() {
+        return intervalMillis;
+    }
+
+    public double getInstantRotationsPerSecond() {
+        return instantRotationsPerSecond;
+    }
+
+    public double getMeanRotationsPerSecond() {
+        return meanRotationsPerSecond;
+    }
+
+    public double getInstantCps() {
+        return instantCps;
+    }
+
+    public double getMeanCps() {
+        return meanCps;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "[%s] %s yawΔ=%.3f pitchΔ=%.3f interval=%dms rps=%.2f(mean=%.2f) cps=%.2f(mean=%.2f)",
+                FORMATTER.format(timestamp), packetType, yawDelta, pitchDelta, intervalMillis,
+                instantRotationsPerSecond, meanRotationsPerSecond, instantCps, meanCps);
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/combat/ViolationBuffer.java
+++ b/anticheat/src/main/java/com/example/anticheat/combat/ViolationBuffer.java
@@ -1,0 +1,48 @@
+package com.example.anticheat.combat;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Simple violation buffer that decays over time and notifies the punishment manager when the
+ * severity crosses the configured threshold.
+ */
+public final class ViolationBuffer {
+    private final double threshold;
+    private final double decayPerSecond;
+    private final PunishmentManager punishmentManager;
+    private final AtomicReference<Long> lastUpdate = new AtomicReference<>();
+
+    private double level;
+
+    public ViolationBuffer(double threshold, Duration decayInterval, PunishmentManager punishmentManager) {
+        this.threshold = threshold;
+        this.decayPerSecond = threshold <= 0 ? 0 : threshold / Math.max(1.0, decayInterval.toSeconds());
+        this.punishmentManager = Objects.requireNonNull(punishmentManager, "punishmentManager");
+    }
+
+    public synchronized void addViolation(String playerName, double amount, long timestamp, String reason) {
+        decay(timestamp);
+        level += amount;
+        if (level >= threshold) {
+            punishmentManager.flagSuspect(playerName, reason, level);
+            level = threshold * 0.5; // provide some hysteresis to avoid constant firing
+        }
+    }
+
+    public synchronized double getLevel(long timestamp) {
+        decay(timestamp);
+        return level;
+    }
+
+    private void decay(long timestamp) {
+        Long previous = lastUpdate.getAndSet(timestamp);
+        if (previous == null || decayPerSecond <= 0) {
+            return;
+        }
+        long deltaMillis = Math.max(0, timestamp - previous);
+        double decayAmount = (deltaMillis / 1000.0) * decayPerSecond;
+        level = Math.max(0.0, level - decayAmount);
+    }
+}

--- a/anticheat/src/main/java/com/example/anticheat/command/DumpTracesCommand.java
+++ b/anticheat/src/main/java/com/example/anticheat/command/DumpTracesCommand.java
@@ -1,0 +1,42 @@
+package com.example.anticheat.command;
+
+import com.example.anticheat.combat.PacketMonitor;
+import com.example.anticheat.combat.TraceEntry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Developer command that dumps recent packet traces for a player.
+ */
+public final class DumpTracesCommand {
+    private final PacketMonitor monitor;
+
+    public DumpTracesCommand(PacketMonitor monitor) {
+        this.monitor = Objects.requireNonNull(monitor, "monitor");
+    }
+
+    public void execute(UUID playerId, Appendable output) {
+        Objects.requireNonNull(playerId, "playerId");
+        Objects.requireNonNull(output, "output");
+        List<TraceEntry> entries = monitor.dumpTraces(playerId);
+        if (entries.isEmpty()) {
+            appendLine(output, "No trace data recorded for player " + playerId + ".");
+            return;
+        }
+        appendLine(output, "Dumping " + entries.size() + " packets for player " + playerId + ":");
+        for (TraceEntry entry : entries) {
+            appendLine(output, entry.toString());
+        }
+    }
+
+    private static void appendLine(Appendable output, String value) {
+        try {
+            output.append(value).append('\n');
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a combat packet monitor that logs attack and rotation data, tracks rolling combat metrics, and feeds violation buffers
- implement heuristics for yaw locking and constant clicks-per-second that report to the punishment manager
- provide utilities for capturing diagnostic traces and rolling statistic helpers used by the monitor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce4b0d880832599827f4255f85a6d